### PR TITLE
Code tidies to the pairs loading routines.

### DIFF
--- a/lib/iris/tests/integration/test_pp.py
+++ b/lib/iris/tests/integration/test_pp.py
@@ -359,7 +359,7 @@ class TestVertical(tests.IrisTest):
             data_cube, = iris.fileformats.pp.load_cubes('DUMMY')
 
         msg = "Unable to create instance of HybridHeightFactory. " \
-              "The file(s) ['DUMMY'] don't contain field(s) for 'orography'."
+              "The source data contains no field(s) for 'orography'."
         warn.assert_called_once_with(msg)
 
         # Check the data cube is set up to use hybrid height.


### PR DESCRIPTION
This effort attempts to tidy up the duplicated code between `rules.load_pairs_from_fields` and `rules.load_cubes`.
It also makes the 'resolve references' call operate on a  single cube, which I thought was nicer.
