### PR TITLE
Replace biggus ndarray with lazy as_concrete_data in pp pyke rules.

### DIFF
--- a/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
+++ b/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb
@@ -1647,9 +1647,10 @@ fc_extras
             # the last one. Test based on shape to support different
             # dimension names.
             if cf_bounds_var.shape[:-1] != cf_coord_var.shape:
-                # Resolving the data to a numpy array for compatibility with
-                # array creators (i.e. LazyArray or Dask)
-                bounds_data = bounds_data.ndarray()
+                bounds_data = iris._lazy_data.as_concrete_data(bounds_data)
+                # Resolving the data to a numpy array (i.e. *not* masked) for
+                # compatibility with array creators (i.e. LazyArray or Dask)
+                bounds_data = np.asarray(bounds_data)
                 bounds_data = reorder_bounds_data(bounds_data, cf_bounds_var,
                                                   cf_coord_var)
         else:


### PR DESCRIPTION
Fixes this test failure:
```
======================================================================
ERROR: test_slowest_varying_vertex_dim (iris.tests.unit.fileformats.pyke_rules.compiled_krb.fc_rules_cf_fc.test_build_auxiliary_coordinate.TestBoundsVertexDim)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/miniconda/envs/test-environment/lib/python2.7/site-packages/Iris-1.12.0.dev0-py2.7-linux-x86_64.egg/iris/tests/unit/fileformats/pyke_rules/compiled_krb/fc_rules_cf_fc/test_build_auxiliary_coordinate.py", line 101, in test_slowest_varying_vertex_dim
    build_auxiliary_coordinate(self.engine, self.cf_coord_var)
  File "/home/travis/miniconda/envs/test-environment/lib/python2.7/site-packages/Iris-1.12.0.dev0-py2.7-linux-x86_64.egg/iris/fileformats/_pyke_rules/compiled_krb/fc_rules_cf_fc.py", line 1982, in build_auxiliary_coordinate
    bounds_data = bounds_data.ndarray()
AttributeError: 'Array' object has no attribute 'ndarray'
```