### PR TITLE
Fixes for biggus array checks

### DIFF
--- a/lib/iris/tests/integration/test_aggregated_cube.py
+++ b/lib/iris/tests/integration/test_aggregated_cube.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/integration/test_aggregated_cube.py
+++ b/lib/iris/tests/integration/test_aggregated_cube.py
@@ -23,8 +23,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris.tests as tests
 
-import biggus
-
 import iris
 from iris.analysis import MEAN
 
@@ -37,15 +35,16 @@ class Test_aggregated_by(tests.IrisTest):
         cube = iris.load_cube(problem_test_file)
 
         # Test aggregating by aux coord, notably the `forecast_period` aux
-        # coord on `cube`, whose `_points` attribute is of type
-        # :class:`biggus.Array`. This test then ensures that
-        # aggregating using `points` instead is successful.
+        # coord on `cube`, whose `_points` attribute is a lazy array.
+        # This test then ensures that aggregating using `points` instead is
+        # successful.
 
-        # First confirm we've got a `biggus.Array`.
+        # First confirm we've got a lazy array.
         # NB. This checks the merge process in `load_cube()` hasn't
         # triggered the load of the coordinate's data.
         forecast_period_coord = cube.coord('forecast_period')
-        self.assertIsInstance(forecast_period_coord._points, biggus.Array)
+        self.assertTrue(forecast_period_coord._points.all(),
+                        iris._lazy_data.is_lazy_data)
 
         # Now confirm we can aggregate along this coord.
         res_cube = cube.aggregated_by('forecast_period', MEAN)

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -33,7 +33,6 @@ import shutil
 import stat
 import tempfile
 
-import biggus
 import netCDF4 as nc
 import numpy as np
 import numpy.ma as ma
@@ -111,7 +110,8 @@ class TestNetCDFLoad(tests.IrisTest):
         cube = iris.load_cube(tests.get_data_path(
             ('NetCDF', 'rotated', 'xy', 'rotPole_landAreaFraction.nc')))
         # Make sure the AuxCoords have lazy data.
-        self.assertIsInstance(cube.coord('latitude')._points, biggus.Array)
+        self.assertTrue(cube.coord('latitude')._points.all(),
+                        iris._lazy_data.is_lazy_data)
         self.assertCML(cube, ('netcdf', 'netcdf_rotated_xy_land.cml'))
 
     def test_load_rotated_xyt_precipitation(self):

--- a/lib/iris/tests/test_netcdf.py
+++ b/lib/iris/tests/test_netcdf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/test_pp_module.py
+++ b/lib/iris/tests/test_pp_module.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -22,11 +22,11 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 from copy import deepcopy
+import dask
 import os
 from types import GeneratorType
 import unittest
 
-import biggus
 import netcdftime
 from numpy.testing import assert_array_equal
 
@@ -44,7 +44,7 @@ class TestPPCopy(tests.IrisTest):
     def test_copy_field_deferred(self):
         field = next(pp.load(self.filename))
         clone = field.copy()
-        self.assertIsInstance(clone._data, biggus.Array)
+        self.assertIsInstance(clone._data, dask.array.Array)
         self.assertEqual(field, clone)
         clone.lbyr = 666
         self.assertNotEqual(field, clone)
@@ -52,7 +52,7 @@ class TestPPCopy(tests.IrisTest):
     def test_deepcopy_field_deferred(self):
         field = next(pp.load(self.filename))
         clone = deepcopy(field)
-        self.assertIsInstance(clone._data, biggus.Array)
+        self.assertIsInstance(clone._data, dask.array.Array)
         self.assertEqual(field, clone)
         clone.lbyr = 666
         self.assertNotEqual(field, clone)

--- a/lib/iris/tests/unit/fileformats/grib/message/test_GribMessage.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test_GribMessage.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2017, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/tests/unit/fileformats/grib/message/test_GribMessage.py
+++ b/lib/iris/tests/unit/fileformats/grib/message/test_GribMessage.py
@@ -29,9 +29,9 @@ import iris.tests as tests
 
 from abc import ABCMeta, abstractmethod
 
-import biggus
 import numpy as np
 
+import iris._lazy_data
 from iris.exceptions import TranslationError
 from iris.fileformats.grib.message import GribMessage
 from iris.tests import mock
@@ -182,7 +182,7 @@ class Mixin_data__grid_template(six.with_metaclass(ABCMeta, object)):
              6: SECTION_6_NO_BITMAP,
              7: {'codedValues': np.arange(12)}})
         data = message.data
-        self.assertIsInstance(data, biggus.Array)
+        self.assertTrue(data, iris._lazy_data.is_lazy_data)
         self.assertEqual(data.shape, (3, 4))
         self.assertEqual(data.dtype, np.floating)
         self.assertIs(data.fill_value, np.nan)


### PR DESCRIPTION
Changed most occurrences of biggus.Array instance checks to either dask.array.Array instance checks or lazy data checks